### PR TITLE
Insert a rescue workflow in commands.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies:

--- a/src/lsst/cm/tools/cli/commands.py
+++ b/src/lsst/cm/tools/cli/commands.py
@@ -66,6 +66,20 @@ def insert(
 @cli.command()
 @options.dbi()
 @options.fullname()
+@options.config_block()
+def insert_rescue(
+    dbi: DbInterface,
+    config_block: str,
+    **kwargs: Any,
+) -> None:
+    """Insert a rescue workflow"""
+    the_db_id = dbi.get_db_id(**kwargs)
+    dbi.insert_rescue(the_db_id, config_block, **kwargs)
+
+
+@cli.command()
+@options.dbi()
+@options.fullname()
 @options.production()
 @options.campaign()
 @options.step()

--- a/tests/test_db_id.py
+++ b/tests/test_db_id.py
@@ -3,7 +3,6 @@ from lsst.cm.tools.core.utils import LevelEnum
 
 
 def test_db_id() -> None:
-
     db_top_id = DbId()
     assert db_top_id.to_tuple() == (None, None, None, None, None)
     assert db_top_id.level() is None

--- a/tests/test_sql_interface.py
+++ b/tests/test_sql_interface.py
@@ -14,7 +14,6 @@ from lsst.cm.tools.db.sqlalch_interface import SQLAlchemyInterface
 def run_production(
     iface: SQLAlchemyInterface, campaign_name: str, config_name: str, config_yaml: str
 ) -> None:
-
     db_p_id = iface.get_db_id(production_name="example")
 
     config = iface.parse_config(config_name, config_yaml)
@@ -34,7 +33,6 @@ def run_production(
     db_c_id = iface.get_db_id(production_name="example", campaign_name=campaign_name)
 
     for step_name in ["step1", "step2", "step3"]:
-
         result = iface.queue_jobs(LevelEnum.campaign, db_c_id)
         # assert result
 

--- a/tests/test_sql_interface.py
+++ b/tests/test_sql_interface.py
@@ -65,7 +65,6 @@ def run_production(
 
 
 def test_full_example() -> None:
-
     try:
         os.unlink("test.db")
     except OSError:  # pragma: no cover
@@ -196,7 +195,6 @@ def test_full_example() -> None:
 
 
 def test_failed_workflows() -> None:
-
     try:
         os.unlink("fail.db")
     except OSError:  # pragma: no cover
@@ -298,7 +296,6 @@ def test_failed_workflows() -> None:
 
 
 def test_recover_failed() -> None:
-
     try:
         os.unlink("fail.db")
     except OSError:  # pragma: no cover
@@ -370,7 +367,6 @@ def test_recover_failed() -> None:
 
 
 def test_failed_scripts() -> None:
-
     try:
         os.unlink("fail.db")
     except OSError:  # pragma: no cover
@@ -426,7 +422,6 @@ def test_failed_scripts() -> None:
 
 
 def test_script_interface() -> None:
-
     try:
         os.unlink("fail.db")
     except OSError:  # pragma: no cover
@@ -496,7 +491,6 @@ def test_script_interface() -> None:
 
 
 def test_insert() -> None:
-
     try:
         os.unlink("test.db")
     except OSError:  # pragma: no cover
@@ -568,13 +562,11 @@ def test_insert() -> None:
 
 
 def test_bad_db() -> None:
-
     with pytest.raises(RuntimeError):
         SQLAlchemyInterface("sqlite:///bad.db", echo=False)
 
 
 def test_table_repr() -> None:
-
     depend = Dependency()
     assert repr(depend)
 


### PR DESCRIPTION
Do we have the rest of the infrastructure to do this in eac-for-orion or should I keep adding it in on this branch?