### PR TITLE
DM-38007: Refine error_code_decisions.yaml to match ErrorTable format better

### DIFF
--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -10,7 +10,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         psfex:
             diagMessage: >
@@ -20,7 +20,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         FWHM_value_of_nan:
             diagMessage: "Failed to execute payload:PSF at (.*) has an invalid FWHM value of nan"
@@ -28,7 +28,7 @@ pandaErrorCode:
             ticket: ["DM-37089"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         NaN_to_int_calibrate:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
@@ -36,7 +36,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         no_use_for_photocal:
             diagMessage: "Failed to execute payload:No matches to use for photocal"
@@ -44,7 +44,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         NaN_to_int_detection:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
@@ -52,7 +52,7 @@ pandaErrorCode:
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         all_pixels_masked:
             diagMessage: "Failed to execute payload:All pixels masked. Cannot estimate background"
@@ -60,7 +60,7 @@ pandaErrorCode:
             ticket: ["DM-37837", "DM-37570"]
             resolved: True
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         too_many_indicies:
             diagMessage: "too many indices for array: array is 1-dimensional, but 2 were indexed"
@@ -68,7 +68,7 @@ pandaErrorCode:
             ticket: ["DM-37837", "DM-37570"]
             resolved: True
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         vague_finalizeCharacterization:
             diagMessage: "Failed to execute payload"
@@ -76,7 +76,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         do_compute_kernel_image:
             diagMessage: >
@@ -86,7 +86,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         kernel_candidacy:
             diagMessage: "Failed to execute payload:Cannot find any objects suitable for KernelCandidacy"
@@ -94,7 +94,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         psf_matching_kernel_subtractImages:
             diagMessage: "Failed to execute payload:Unable to calculate psf matching kernel"
@@ -102,7 +102,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37089"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         array_sample_empty:
             diagMessage: "Failed to execute payload:array of sample points is empty"
@@ -110,7 +110,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         fp_xp:
             diagMessage: "Failed to execute payload:fp and xp are not of the same length."
@@ -118,7 +118,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         parquet_formatter:
             diagMessage: >
@@ -128,7 +128,7 @@ pandaErrorCode:
             ticket: ["DM-36306", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         fgcm_380:
             diagMessage: "Failed to execute payload:(380, 40)"
@@ -136,7 +136,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0
         remote_io:
             diagMessage: "(psycopg2.errors.InternalError_) could not read block .* in file \".*\": Remote I/O error"
@@ -144,7 +144,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: True # double check this
             rescue: False
-            flavor: True # later: mark as "usdf"
+            flavor: "usdf" # later: mark as "usdf"
             intensity: 0
     trans, 1:
         p_aperture_correction:
@@ -157,7 +157,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_psf_matching_kernel:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
@@ -166,7 +166,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         psf_in_GAaP:
             diagMessage: >
@@ -177,7 +177,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-33375", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_psfex:
             diagMessage: "Only spatial variation (ndim == 2) is supported; saw 0"
@@ -186,7 +186,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_no_use_for_photocal:
             diagMessage: >
@@ -197,7 +197,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_NaN_to_int_calibrate:
             diagMessage: >
@@ -208,7 +208,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_FWHM_value_of_nan:
             diagMessage: >
@@ -219,7 +219,7 @@ pandaErrorCode:
             ticket: ["DM-37089", "DM-36763"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         finalizeCharacterization_failed:
             diagMessage: >
@@ -231,7 +231,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         cant_start_new_thread:
             diagMessage: "RuntimeError: can't start new thread"
@@ -240,7 +240,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         rchar:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic rchar from .* to .*"
@@ -249,7 +249,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         read_bytes:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic read_bytes from .* to .*"
@@ -258,7 +258,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         terminate_after_sys_err:
             diagMessage: >
@@ -268,7 +268,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         pthread_create:
             diagMessage: "ERROR; return code from pthread_create() is 11 Error detail: Resource temporarily unavailable"
@@ -277,7 +277,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         url_timeout:
             diagMessage: >
@@ -288,7 +288,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
         p_fgcm_380:
             diagMessage: "Exception KeyError: (380, 40)"
@@ -297,7 +297,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0
         keyerror_0:
             diagMessage: |
@@ -308,7 +308,7 @@ pandaErrorCode:
             ticket: ["DM-37786", "DM-37570"]
             resolved: True
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0
         outside_image_bounds:
             diagMessage: >
@@ -319,7 +319,7 @@ pandaErrorCode:
             ticket: ["DM-35722", "DM-36066"]
             resolved: True
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_NaN_to_int_detection:
             diagMessage: >
@@ -330,7 +330,7 @@ pandaErrorCode:
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_all_pixels_masked:
             diagMessage: "All pixels masked. Cannot estimate background"
@@ -339,7 +339,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: True
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_psf_matching_kernel_subtractImages:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
@@ -348,7 +348,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         cannot_compute_coaddpsf:
             diagMessage: >
@@ -362,7 +362,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_kernel_candidacy:
             diagMessage: >
@@ -373,7 +373,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_do_compute_kernel_image:
             diagMessage: >
@@ -384,7 +384,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         kernel_does_not_exist:
             diagMessage: "Original kernel does not exist {0}; Visiting candidate {1}{{}}"
@@ -393,7 +393,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         kernel_sum:
             diagMessage: "Unable to determine kernel sum; 0 candidates"
@@ -402,7 +402,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_NaN_to_int_subtractImages:
             diagMessage: "Exception ValueError: cannot convert float NaN to integer"
@@ -411,7 +411,7 @@ pandaErrorCode:
             ticket: ["DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_array_sample_empty:
             diagMessage: "array of sample points is empty"
@@ -420,7 +420,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_fp_xp:
             diagMessage: "fp and xp are not of the same length."
@@ -429,7 +429,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         u_psf:
             diagMessage: >
@@ -440,7 +440,7 @@ pandaErrorCode:
             ticket: ["DM-36305", "DM-36356"]
             resolved: False
             rescue: False
-            flavor: False
+            flavor: "pipelines"
             intensity: 0.001
         p_remote_io:
             diagMessage: >
@@ -451,7 +451,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: True # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
             rescue: False
-            flavor: True # later: mark as "usdf"
+            flavor: "usdf"
             intensity: 0
     taskbuffer, 300:
         failed_while_starting_job:
@@ -461,7 +461,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36845", "DM-36763"]
             resolved: False
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
     taskbuffer, 102:
         expired_in_pending:
@@ -471,7 +471,7 @@ pandaErrorCode:
             ticket: ["DM-37089"]
             resolved: False
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
     pilot, 1344:
         resource_temporarily_unavailable:
@@ -481,7 +481,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
     trans, 134:
         sigabrt:
@@ -492,7 +492,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
     jobdispatcher, 102:
         no_reply:
@@ -502,7 +502,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
     jobdispatcher, 100:
         lost_heartbeat:
@@ -512,7 +512,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
     pilot, 1098:
         no_space_on_disk:
@@ -522,7 +522,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0
     trans, 137:
         sigkill:
@@ -532,5 +532,5 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36356", "DM-36741"]
             resolved: True
             rescue: True
-            flavor: True
+            flavor: "panda"
             intensity: 0

--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -1,5 +1,23 @@
 description: Lookup table for error codes from PanDA and error logs from science pipelines on HSC-RC2.
-
+legend:
+    pandaErrorCode: >
+        The error code given by PanDA describing the issue. This is a string describing the type of PanDA
+        error followed by a number which gives the specific type of PanDA error.
+    diagMessage: This is the diagnostic message given by the PanDA and pipeline logs.
+    pipetask: This is the specific pipetask where the error occurred.
+    ticket: >
+        Any Jira tickets associated with this issue. This can be the processing run where the error
+        came up or a ticket associated with fixing a bug.
+    resolved: >
+        Do we think we have solved this issue? i.e., have we reported and fixed a bug associated with this error?
+        This is most useful in cases where the issue seems to have been addressed. If "resolved==True" and the error
+        still comes up, we know we missed something and have to stop to look at it.
+    rescue: Can the issue associated with this error be solved with a rescue?
+    flavor: Where did this error come from? The science pipelines? PanDA? USDF?
+    intensity: >
+        How many instances of this error may occur before we must stop production and investigate? This float value
+        is a percentage. i.e., if "intensity==0.001" then we can lose 0.1% of the data products due to this error.
+        If "intensity==0" we have to stop production and investigate with any single occurrence.
 pandaErrorCode:
     pilot, 1305:
         aperture_correction:

--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -10,18 +10,18 @@ pandaErrorCode:
             function: characterizeImage
             known: 1
             ticket: ["DM-37483", "DM-37089", "DM-36763", "DM-36356"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_psf_matching_kernel:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
             function: characterizeImage
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36763", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         psf_in_GAaP:
             diagMessage: >
@@ -30,18 +30,18 @@ pandaErrorCode:
             function: characterizeImage
             known: 1
             ticket: ["DM-37483", "DM-33375", "DM-36763", "DM-36356"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_psfex:
             diagMessage: "Only spatial variation (ndim == 2) is supported; saw 0"
             function: characterizeImage
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_no_use_for_photocal:
             diagMessage: >
@@ -50,9 +50,9 @@ pandaErrorCode:
             function: calibrate
             known: 1
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_NaN_to_int_calibrate:
             diagMessage: >
@@ -61,9 +61,9 @@ pandaErrorCode:
             function: calibrate
             known: 1
             ticket: ["DM-36356"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_FWHM_value_of_nan:
             diagMessage: >
@@ -72,9 +72,9 @@ pandaErrorCode:
             function: calibrate
             known: 1
             ticket: ["DM-37089", "DM-36763"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         finalizeCharacterization_failed:
             diagMessage: >
@@ -84,36 +84,36 @@ pandaErrorCode:
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         cant_start_new_thread:
             diagMessage: "RuntimeError: can't start new thread"
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         rchar:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic rchar from .* to .*"
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         read_bytes:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic read_bytes from .* to .*"
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         terminate_after_sys_err:
             diagMessage: >
@@ -121,18 +121,18 @@ pandaErrorCode:
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         pthread_create:
             diagMessage: "ERROR; return code from pthread_create() is 11 Error detail: Resource temporarily unavailable"
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         url_timeout:
             diagMessage: >
@@ -141,18 +141,18 @@ pandaErrorCode:
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         p_fgcm_380:
             diagMessage: "Exception KeyError: (380, 40)"
             function: fgcmBuildStarsTable
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0
         keyerror_0:
             diagMessage: |
@@ -161,9 +161,9 @@ pandaErrorCode:
             function: updateVisitSummary
             known: 1
             ticket: ["DM-37786", "DM-37570"]
-            resolved: 1
-            rescue: 0
-            flavor: 0
+            resolved: True
+            rescue: False
+            flavor: False
             intensity: 0
         outside_image_bounds:
             diagMessage: >
@@ -172,9 +172,9 @@ pandaErrorCode:
             function: measure
             known: 1
             ticket: ["DM-35722", "DM-36066"]
-            resolved: 1
-            rescue: 0
-            flavor: 0
+            resolved: True
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_NaN_to_int_detection:
             diagMessage: >
@@ -183,27 +183,43 @@ pandaErrorCode:
             function: detection
             known: 1
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_all_pixels_masked:
             diagMessage: "All pixels masked. Cannot estimate background"
             function: detection
             known: 1
+<<<<<<< HEAD
             ticket: ["DM-37570"]
             resolved: 1
             rescue: 0
             flavor: 0
+=======
+            ticket: ["DM-37837", "DM-37570"]
+            resolved: True
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        p_too_many_indicies:
+            diagMessage: "IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed"
+            function: detection
+            known: 1
+            ticket: ["DM-37837", "DM-37570"]
+            resolved: True
+            rescue: False
+            flavor: False
+>>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
             intensity: 0.001
         p_psf_matching_kernel_subtractImages:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
             function: subtractImages
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         cannot_compute_coaddpsf:
             diagMessage: >
@@ -215,9 +231,9 @@ pandaErrorCode:
             function: subtractImages
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_kernel_candidacy:
             diagMessage: >
@@ -226,9 +242,9 @@ pandaErrorCode:
             function: subtractImages
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_do_compute_kernel_image:
             diagMessage: >
@@ -237,54 +253,54 @@ pandaErrorCode:
             function: subtractImages
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         kernel_does_not_exist:
             diagMessage: "Original kernel does not exist {0}; Visiting candidate {1}{{}}"
             function: subtractImages
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         kernel_sum:
             diagMessage: "Unable to determine kernel sum; 0 candidates"
             function: subtractImages
             known: 1
             ticket: ["DM-37483", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_NaN_to_int_subtractImages:
             diagMessage: "Exception ValueError: cannot convert float NaN to integer"
             function: subtractImages
             known: 1
             ticket: ["DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_array_sample_empty:
             diagMessage: "array of sample points is empty"
             function: subtractImages
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_fp_xp:
             diagMessage: "fp and xp are not of the same length."
             function: subtractImages
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         u_psf:
             diagMessage: >
@@ -293,9 +309,9 @@ pandaErrorCode:
             function: catalogMatchTract
             known: 1
             ticket: ["DM-36305", "DM-36356"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         p_remote_io:
             diagMessage: >
@@ -304,9 +320,15 @@ pandaErrorCode:
             function: mergeExecutionButler
             known: 1
             ticket: ["DM-37570"]
+<<<<<<< HEAD
             resolved: 1 # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
             rescue: 0
             flavor: 1 # later: mark as "usdf"
+=======
+            resolved: True # double check this
+            rescue: False
+            flavor: True # later: mark as "usdf"
+>>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
             intensity: 0
     pilot, 1305:
         aperture_correction:
@@ -316,9 +338,9 @@ pandaErrorCode:
             function: characterizeImage
             known: 1
             ticket: ["DM-37483", "DM-37089"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         psfex:
             diagMessage: >
@@ -327,63 +349,75 @@ pandaErrorCode:
             function: characterizeImage
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         FWHM_value_of_nan:
             diagMessage: "Failed to execute payload:PSF at (.*) has an invalid FWHM value of nan"
             function: calibrate
             known: 1
             ticket: ["DM-37089"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         NaN_to_int_calibrate:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
             function: calibrate
             known: 1
             ticket: ["DM-36356"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         no_use_for_photocal:
             diagMessage: "Failed to execute payload:No matches to use for photocal"
             function: calibrate
             known: 1
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         NaN_to_int_detection:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
             function: detection
             known: 1
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         all_pixels_masked:
             diagMessage: "Failed to execute payload:All pixels masked. Cannot estimate background"
             function: detection
             known: 1
             ticket: ["DM-37837", "DM-37570"]
-            resolved: 1
-            rescue: 0
-            flavor: 0
+            resolved: True
+            rescue: False
+            flavor: False
             intensity: 0.001
+<<<<<<< HEAD
+=======
+        too_many_indicies:
+            diagMessage: "too many indices for array: array is 1-dimensional, but 2 were indexed"
+            function: detection
+            known: 1
+            ticket: ["DM-37837", "DM-37570"]
+            resolved: True
+            rescue: False
+            flavor: False
+            intensity: 0.001
+>>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
         vague_finalizeCharacterization:
             diagMessage: "Failed to execute payload"
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
         do_compute_kernel_image:
             diagMessage: >
@@ -392,45 +426,45 @@ pandaErrorCode:
             function: subtractImages
             known: 1
             ticket: ["DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         kernel_candidacy:
             diagMessage: "Failed to execute payload:Cannot find any objects suitable for KernelCandidacy"
             function: subtractImages
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         psf_matching_kernel_subtractImages:
             diagMessage: "Failed to execute payload:Unable to calculate psf matching kernel"
             function: subtractImages
             known: 1
             ticket: ["DM-37570", "DM-37089"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         array_sample_empty:
             diagMessage: "Failed to execute payload:array of sample points is empty"
             function: subtractImages
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         fp_xp:
             diagMessage: "Failed to execute payload:fp and xp are not of the same length."
             function: subtractImages
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         parquet_formatter:
             diagMessage: >
@@ -439,27 +473,27 @@ pandaErrorCode:
             function: catalogMatchTract
             known: 1
             ticket: ["DM-36306", "DM-36356"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0.001
         fgcm_380:
             diagMessage: "Failed to execute payload:(380, 40)"
             function: fgcmBuildStarsTable
             known: 1
             ticket: ["DM-37570"]
-            resolved: 0
-            rescue: 0
-            flavor: 0
+            resolved: False
+            rescue: False
+            flavor: False
             intensity: 0
         remote_io:
             diagMessage: "(psycopg2.errors.InternalError_) could not read block .* in file \".*\": Remote I/O error"
             function: mergeExecutionButler
             known: 1
             ticket: ["DM-37570"]
-            resolved: 1 # double check this
-            rescue: 0
-            flavor: 1 # later: mark as "usdf"
+            resolved: True # double check this
+            rescue: False
+            flavor: True # later: mark as "usdf"
             intensity: 0
     taskbuffer, 300:
         failed_while_starting_job:
@@ -467,9 +501,9 @@ pandaErrorCode:
             function:
             known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36845", "DM-36763"]
-            resolved: 0
-            rescue: 1
-            flavor: 1
+            resolved: False
+            rescue: True
+            flavor: True
             intensity: 0
     taskbuffer, 102:
         expired_in_pending:
@@ -477,9 +511,9 @@ pandaErrorCode:
             function:
             known: 1
             ticket: ["DM-37089"]
-            resolved: 0
-            rescue: 1
-            flavor: 1
+            resolved: False
+            rescue: True
+            flavor: True
             intensity: 0
     pilot, 1344:
         resource_temporarily_unavailable:
@@ -487,9 +521,9 @@ pandaErrorCode:
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
     trans, 134:
         sigabrt:
@@ -498,9 +532,9 @@ pandaErrorCode:
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
     jobdispatcher, 102:
         no_reply:
@@ -508,9 +542,9 @@ pandaErrorCode:
             function: finalizeCharacterization
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
     jobdispatcher, 100:
         lost_heartbeat:
@@ -518,9 +552,9 @@ pandaErrorCode:
             function:
             known: 1
             ticket: ["DM-36356"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
     pilot, 1098:
         no_space_on_disk:
@@ -528,17 +562,24 @@ pandaErrorCode:
             function: forcedPhotCcd
             known: 1
             ticket: ["DM-36066"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
+            resolved: True
+            rescue: True
+            flavor: True
             intensity: 0
     trans, 137:
         sigkill:
             diagMessage: "Transform received signal SIGKILL"
             function:
             known: 1
+<<<<<<< HEAD
             ticket: ["DM-37570", "DM-37483", "DM-36356", "DM-36741"]
             resolved: 1
             rescue: 1
             flavor: 1
+=======
+            ticket: ["DM-37483", "DM-36356", "DM-36741"]
+            resolved: True
+            rescue: True
+            flavor: True
+>>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
             intensity: 0

--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -191,26 +191,10 @@ pandaErrorCode:
             diagMessage: "All pixels masked. Cannot estimate background"
             function: detection
             known: 1
-<<<<<<< HEAD
             ticket: ["DM-37570"]
-            resolved: 1
-            rescue: 0
-            flavor: 0
-=======
-            ticket: ["DM-37837", "DM-37570"]
             resolved: True
             rescue: False
             flavor: False
-            intensity: 0.001
-        p_too_many_indicies:
-            diagMessage: "IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed"
-            function: detection
-            known: 1
-            ticket: ["DM-37837", "DM-37570"]
-            resolved: True
-            rescue: False
-            flavor: False
->>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
             intensity: 0.001
         p_psf_matching_kernel_subtractImages:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
@@ -320,15 +304,9 @@ pandaErrorCode:
             function: mergeExecutionButler
             known: 1
             ticket: ["DM-37570"]
-<<<<<<< HEAD
-            resolved: 1 # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
-            rescue: 0
-            flavor: 1 # later: mark as "usdf"
-=======
-            resolved: True # double check this
+            resolved: True # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
             rescue: False
             flavor: True # later: mark as "usdf"
->>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
             intensity: 0
     pilot, 1305:
         aperture_correction:
@@ -398,18 +376,6 @@ pandaErrorCode:
             rescue: False
             flavor: False
             intensity: 0.001
-<<<<<<< HEAD
-=======
-        too_many_indicies:
-            diagMessage: "too many indices for array: array is 1-dimensional, but 2 were indexed"
-            function: detection
-            known: 1
-            ticket: ["DM-37837", "DM-37570"]
-            resolved: True
-            rescue: False
-            flavor: False
-            intensity: 0.001
->>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
         vague_finalizeCharacterization:
             diagMessage: "Failed to execute payload"
             function: finalizeCharacterization
@@ -571,15 +537,8 @@ pandaErrorCode:
             diagMessage: "Transform received signal SIGKILL"
             function:
             known: 1
-<<<<<<< HEAD
             ticket: ["DM-37570", "DM-37483", "DM-36356", "DM-36741"]
-            resolved: 1
-            rescue: 1
-            flavor: 1
-=======
-            ticket: ["DM-37483", "DM-36356", "DM-36741"]
             resolved: True
             rescue: True
             flavor: True
->>>>>>> e7a1ca9 (Made boolean fields actual boolean values)
             intensity: 0

--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -1,6 +1,151 @@
 description: Lookup table for error codes from PanDA and error logs from science pipelines on HSC-RC2.
 
 pandaErrorCode:
+    pilot, 1305:
+        aperture_correction:
+            diagMessage: >
+                Unable to measure aperture correction for required algorithm 'modelfit_CModel': only .* sources, but
+                require at least 2
+            function: characterizeImage
+            ticket: ["DM-37483", "DM-37089"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        psfex:
+            diagMessage: >
+                File "src/PsfexPsf.cc", line 233, in virtual std:shared_ptr > lsst:meas:extensions:psfex:PsfexPsf:
+                _doComputeImage(const Point2D&, const lsst:afw:image:Color&, const Point2D&) const
+            function: characterizeImage
+            ticket: ["DM-37570"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        FWHM_value_of_nan:
+            diagMessage: "Failed to execute payload:PSF at (.*) has an invalid FWHM value of nan"
+            function: calibrate
+            ticket: ["DM-37089"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        NaN_to_int_calibrate:
+            diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
+            function: calibrate
+            ticket: ["DM-36356"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        no_use_for_photocal:
+            diagMessage: "Failed to execute payload:No matches to use for photocal"
+            function: calibrate
+            ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        NaN_to_int_detection:
+            diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
+            function: detection
+            ticket: ["DM-36763", "DM-36356", "DM-36066"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        all_pixels_masked:
+            diagMessage: "Failed to execute payload:All pixels masked. Cannot estimate background"
+            function: detection
+            ticket: ["DM-37837", "DM-37570"]
+            resolved: True
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        too_many_indicies:
+            diagMessage: "too many indices for array: array is 1-dimensional, but 2 were indexed"
+            function: detection
+            ticket: ["DM-37837", "DM-37570"]
+            resolved: True
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        vague_finalizeCharacterization:
+            diagMessage: "Failed to execute payload"
+            function: finalizeCharacterization
+            ticket: ["DM-36066"]
+            resolved: True
+            rescue: True
+            flavor: True
+            intensity: 0
+        do_compute_kernel_image:
+            diagMessage: >
+                Failed to execute payload:File \"src/CoaddPsf.cc\", line 254, in virtual std:shared_ptr > lsst:meas:algorithms:
+                CoaddPsf:doComputeKernelImage(const Point2D&, const lsst:afw:image:Color&) const
+            function: subtractImages
+            ticket: ["DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        kernel_candidacy:
+            diagMessage: "Failed to execute payload:Cannot find any objects suitable for KernelCandidacy"
+            function: subtractImages
+            ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        psf_matching_kernel_subtractImages:
+            diagMessage: "Failed to execute payload:Unable to calculate psf matching kernel"
+            function: subtractImages
+            ticket: ["DM-37570", "DM-37089"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        array_sample_empty:
+            diagMessage: "Failed to execute payload:array of sample points is empty"
+            function: subtractImages
+            ticket: ["DM-37570"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        fp_xp:
+            diagMessage: "Failed to execute payload:fp and xp are not of the same length."
+            function: subtractImages
+            ticket: ["DM-37570"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        parquet_formatter:
+            diagMessage: >
+                Failed to execute payload:Failure from formatter 'lsst.daf.butler.formatters.parquet.ParquetFormatter' for dataset
+                .*
+            function: catalogMatchTract
+            ticket: ["DM-36306", "DM-36356"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0.001
+        fgcm_380:
+            diagMessage: "Failed to execute payload:(380, 40)"
+            function: fgcmBuildStarsTable
+            ticket: ["DM-37570"]
+            resolved: False
+            rescue: False
+            flavor: False
+            intensity: 0
+        remote_io:
+            diagMessage: "(psycopg2.errors.InternalError_) could not read block .* in file \".*\": Remote I/O error"
+            function: mergeExecutionButler
+            ticket: ["DM-37570"]
+            resolved: True # double check this
+            rescue: False
+            flavor: True # later: mark as "usdf"
+            intensity: 0
     trans, 1:
         p_aperture_correction:
             diagMessage: >
@@ -305,159 +450,6 @@ pandaErrorCode:
             known: 1
             ticket: ["DM-37570"]
             resolved: True # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
-            rescue: False
-            flavor: True # later: mark as "usdf"
-            intensity: 0
-    pilot, 1305:
-        aperture_correction:
-            diagMessage: >
-                Unable to measure aperture correction for required algorithm 'modelfit_CModel': only .* sources, but
-                require at least 2
-            function: characterizeImage
-            known: 1
-            ticket: ["DM-37483", "DM-37089"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        psfex:
-            diagMessage: >
-                File "src/PsfexPsf.cc", line 233, in virtual std:shared_ptr > lsst:meas:extensions:psfex:PsfexPsf:
-                _doComputeImage(const Point2D&, const lsst:afw:image:Color&, const Point2D&) const
-            function: characterizeImage
-            known: 1
-            ticket: ["DM-37570"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        FWHM_value_of_nan:
-            diagMessage: "Failed to execute payload:PSF at (.*) has an invalid FWHM value of nan"
-            function: calibrate
-            known: 1
-            ticket: ["DM-37089"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        NaN_to_int_calibrate:
-            diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
-            function: calibrate
-            known: 1
-            ticket: ["DM-36356"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        no_use_for_photocal:
-            diagMessage: "Failed to execute payload:No matches to use for photocal"
-            function: calibrate
-            known: 1
-            ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        NaN_to_int_detection:
-            diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
-            function: detection
-            known: 1
-            ticket: ["DM-36763", "DM-36356", "DM-36066"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        all_pixels_masked:
-            diagMessage: "Failed to execute payload:All pixels masked. Cannot estimate background"
-            function: detection
-            known: 1
-            ticket: ["DM-37837", "DM-37570"]
-            resolved: True
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        vague_finalizeCharacterization:
-            diagMessage: "Failed to execute payload"
-            function: finalizeCharacterization
-            known: 1
-            ticket: ["DM-36066"]
-            resolved: True
-            rescue: True
-            flavor: True
-            intensity: 0
-        do_compute_kernel_image:
-            diagMessage: >
-                Failed to execute payload:File \"src/CoaddPsf.cc\", line 254, in virtual std:shared_ptr > lsst:meas:algorithms:
-                CoaddPsf:doComputeKernelImage(const Point2D&, const lsst:afw:image:Color&) const
-            function: subtractImages
-            known: 1
-            ticket: ["DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        kernel_candidacy:
-            diagMessage: "Failed to execute payload:Cannot find any objects suitable for KernelCandidacy"
-            function: subtractImages
-            known: 1
-            ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        psf_matching_kernel_subtractImages:
-            diagMessage: "Failed to execute payload:Unable to calculate psf matching kernel"
-            function: subtractImages
-            known: 1
-            ticket: ["DM-37570", "DM-37089"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        array_sample_empty:
-            diagMessage: "Failed to execute payload:array of sample points is empty"
-            function: subtractImages
-            known: 1
-            ticket: ["DM-37570"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        fp_xp:
-            diagMessage: "Failed to execute payload:fp and xp are not of the same length."
-            function: subtractImages
-            known: 1
-            ticket: ["DM-37570"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        parquet_formatter:
-            diagMessage: >
-                Failed to execute payload:Failure from formatter 'lsst.daf.butler.formatters.parquet.ParquetFormatter' for dataset
-                .*
-            function: catalogMatchTract
-            known: 1
-            ticket: ["DM-36306", "DM-36356"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0.001
-        fgcm_380:
-            diagMessage: "Failed to execute payload:(380, 40)"
-            function: fgcmBuildStarsTable
-            known: 1
-            ticket: ["DM-37570"]
-            resolved: False
-            rescue: False
-            flavor: False
-            intensity: 0
-        remote_io:
-            diagMessage: "(psycopg2.errors.InternalError_) could not read block .* in file \".*\": Remote I/O error"
-            function: mergeExecutionButler
-            known: 1
-            ticket: ["DM-37570"]
-            resolved: True # double check this
             rescue: False
             flavor: True # later: mark as "usdf"
             intensity: 0

--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -153,7 +153,6 @@ pandaErrorCode:
                 RuntimeError: Unable to measure aperture correction for required algorithm 'modelfit_CModel': only 0 sources, but
                 require at least 2.
             function: characterizeImage
-            known: 1
             ticket: ["DM-37483", "DM-37089", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
@@ -162,7 +161,6 @@ pandaErrorCode:
         p_psf_matching_kernel:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
             function: characterizeImage
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -173,7 +171,6 @@ pandaErrorCode:
                 Failed to solve for PSF matching kernel in GAaP for (.*): Problematic scaling factors = .* Errors: Exception
                 ('Unable to determine kernel sum; 0 candidates')
             function: characterizeImage
-            known: 1
             ticket: ["DM-37483", "DM-33375", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
@@ -182,7 +179,6 @@ pandaErrorCode:
         p_psfex:
             diagMessage: "Only spatial variation (ndim == 2) is supported; saw 0"
             function: characterizeImage
-            known: 1
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -193,7 +189,6 @@ pandaErrorCode:
                 Execution of task 'calibrate' on quantum {.*} failed. Exception
                 RuntimeError: No matches to use for photocal
             function: calibrate
-            known: 1
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: False
             rescue: False
@@ -204,7 +199,6 @@ pandaErrorCode:
                 Execution of task 'calibrate' on quantum {.*} failed. Exception
                 ValueError: cannot convert float NaN to integer
             function: calibrate
-            known: 1
             ticket: ["DM-36356"]
             resolved: False
             rescue: False
@@ -215,7 +209,6 @@ pandaErrorCode:
                 Execution of task 'calibrate' on quantum {.*} failed. Exception
                 ValueError: PSF at (.*) has an invalid FWHM value of nan
             function: calibrate
-            known: 1
             ticket: ["DM-37089", "DM-36763"]
             resolved: False
             rescue: False
@@ -227,7 +220,6 @@ pandaErrorCode:
                 finalizeCharacterization) dataId={.*}> failed; processing will continue for remaining
                 tasks.
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -236,7 +228,6 @@ pandaErrorCode:
         cant_start_new_thread:
             diagMessage: "RuntimeError: can't start new thread"
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -245,7 +236,6 @@ pandaErrorCode:
         rchar:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic rchar from .* to .*"
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -254,7 +244,6 @@ pandaErrorCode:
         read_bytes:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic read_bytes from .* to .*"
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -264,7 +253,6 @@ pandaErrorCode:
             diagMessage: >
                 terminate called after throwing an instance of 'std::system_error' what(): Resource temporarily unavailable
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -273,7 +261,6 @@ pandaErrorCode:
         pthread_create:
             diagMessage: "ERROR; return code from pthread_create() is 11 Error detail: Resource temporarily unavailable"
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -284,7 +271,6 @@ pandaErrorCode:
                 url=/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json, error: TimeoutException: Timeout reached,
                 timeout=20 seconds .. trying to use data from cache=/tmp/atlas_4WNdEEY5/agis_schedconf.cvmfs.json
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -293,7 +279,6 @@ pandaErrorCode:
         p_fgcm_380:
             diagMessage: "Exception KeyError: (380, 40)"
             function: fgcmBuildStarsTable
-            known: 1
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -304,7 +289,6 @@ pandaErrorCode:
                 exposure = input_exposures[detector_id].get()
                 KeyError: 0
             function: updateVisitSummary
-            known: 1
             ticket: ["DM-37786", "DM-37570"]
             resolved: True
             rescue: False
@@ -315,7 +299,6 @@ pandaErrorCode:
                 Execution of task 'measure' on quantum {.*} failed. Exception
                 IndexError: Index (.*) outside image bounds (.*) to (.*).
             function: measure
-            known: 1
             ticket: ["DM-35722", "DM-36066"]
             resolved: True
             rescue: False
@@ -326,7 +309,6 @@ pandaErrorCode:
                 Execution of task 'detection' on quantum {.*} failed. Exception
                 ValueError: cannot convert float NaN to integer
             function: detection
-            known: 1
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -335,7 +317,6 @@ pandaErrorCode:
         p_all_pixels_masked:
             diagMessage: "All pixels masked. Cannot estimate background"
             function: detection
-            known: 1
             ticket: ["DM-37570"]
             resolved: True
             rescue: False
@@ -344,7 +325,6 @@ pandaErrorCode:
         p_psf_matching_kernel_subtractImages:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
             function: subtractImages
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -358,7 +338,6 @@ pandaErrorCode:
                 Color&) const\nCannot compute CoaddPsf at point (.*); no input images at that point. {0} lsst::pex::exceptions::
                 InvalidParameterError: 'Cannot compute CoaddPsf at point (.*); no input images at that point.'
             function: subtractImages
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -369,7 +348,6 @@ pandaErrorCode:
                 Execution of task 'subtractImages' on quantum {.*} failed. Exception
                 RuntimeError: Cannot find any objects suitable for KernelCandidacy
             function: subtractImages
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -380,7 +358,6 @@ pandaErrorCode:
                 File "src/CoaddPsf.cc", line 254, in virtual std:shared_ptr > lsst:meas:
                 algorithms:CoaddPsf:doComputeKernelImage(const Point2D&, const lsst:afw:image:Color&) const"
             function: subtractImages
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -389,7 +366,6 @@ pandaErrorCode:
         kernel_does_not_exist:
             diagMessage: "Original kernel does not exist {0}; Visiting candidate {1}{{}}"
             function: subtractImages
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -398,7 +374,6 @@ pandaErrorCode:
         kernel_sum:
             diagMessage: "Unable to determine kernel sum; 0 candidates"
             function: subtractImages
-            known: 1
             ticket: ["DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -407,7 +382,6 @@ pandaErrorCode:
         p_NaN_to_int_subtractImages:
             diagMessage: "Exception ValueError: cannot convert float NaN to integer"
             function: subtractImages
-            known: 1
             ticket: ["DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -416,7 +390,6 @@ pandaErrorCode:
         p_array_sample_empty:
             diagMessage: "array of sample points is empty"
             function: subtractImages
-            known: 1
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -425,7 +398,6 @@ pandaErrorCode:
         p_fp_xp:
             diagMessage: "fp and xp are not of the same length."
             function: subtractImages
-            known: 1
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -436,7 +408,6 @@ pandaErrorCode:
                 Exception ValueError: Failure from formatter 'lsst.daf.butler.formatters.parquet.ParquetFormatter' for
                 dataset .*: Unrecognized column name 'u_psfFlux_flag'.
             function: catalogMatchTract
-            known: 1
             ticket: ["DM-36305", "DM-36356"]
             resolved: False
             rescue: False
@@ -447,7 +418,6 @@ pandaErrorCode:
                 sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) could not read block .* in file ".*":
                 Remote I/O error
             function: mergeExecutionButler
-            known: 1
             ticket: ["DM-37570"]
             resolved: True # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
             rescue: False
@@ -457,7 +427,6 @@ pandaErrorCode:
         failed_while_starting_job:
             diagMessage: "The worker was failed while the job was starting : .* gridjob roma shared .* FAILED .*."
             function:
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36845", "DM-36763"]
             resolved: False
             rescue: True
@@ -467,7 +436,6 @@ pandaErrorCode:
         expired_in_pending:
             diagMessage: "expired in pending. status unchanged"
             function:
-            known: 1
             ticket: ["DM-37089"]
             resolved: False
             rescue: True
@@ -477,7 +445,6 @@ pandaErrorCode:
         resource_temporarily_unavailable:
             diagMessage: "Exception caught: [Errno 11] Resource temporarily unavailable"
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -488,7 +455,6 @@ pandaErrorCode:
             diagMessage: >
                 New trf: Transform received signal SIGABRT; Old trf: Athena core dump or timeout, or conddb DB connect exception
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -498,7 +464,6 @@ pandaErrorCode:
         no_reply:
             diagMessage: "Sent job didn't receive reply from pilot within 30 min"
             function: finalizeCharacterization
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -508,7 +473,6 @@ pandaErrorCode:
         lost_heartbeat:
             diagMessage: "lost heartbeat"
             function:
-            known: 1
             ticket: ["DM-36356"]
             resolved: True
             rescue: True
@@ -518,7 +482,6 @@ pandaErrorCode:
         no_space_on_disk:
             diagMessage: "too little space left on local disk to run job: .* B (need > .* B)"
             function: forcedPhotCcd
-            known: 1
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -528,7 +491,6 @@ pandaErrorCode:
         sigkill:
             diagMessage: "Transform received signal SIGKILL"
             function:
-            known: 1
             ticket: ["DM-37570", "DM-37483", "DM-36356", "DM-36741"]
             resolved: True
             rescue: True

--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -12,7 +12,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-36763", "DM-36356"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_psf_matching_kernel:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
@@ -21,7 +21,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36763", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         psf_in_GAaP:
             diagMessage: >
@@ -32,7 +32,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-33375", "DM-36763", "DM-36356"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_psfex:
             diagMessage: "Only spatial variation (ndim == 2) is supported; saw 0"
@@ -41,7 +41,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_no_use_for_photocal:
             diagMessage: >
@@ -52,7 +52,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_NaN_to_int_calibrate:
             diagMessage: >
@@ -63,7 +63,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_FWHM_value_of_nan:
             diagMessage: >
@@ -74,7 +74,7 @@ pandaErrorCode:
             ticket: ["DM-37089", "DM-36763"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         finalizeCharacterization_failed:
             diagMessage: >
@@ -86,7 +86,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         cant_start_new_thread:
             diagMessage: "RuntimeError: can't start new thread"
@@ -95,7 +95,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         rchar:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic rchar from .* to .*"
@@ -104,7 +104,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         read_bytes:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic read_bytes from .* to .*"
@@ -113,7 +113,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         terminate_after_sys_err:
             diagMessage: >
@@ -123,7 +123,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         pthread_create:
             diagMessage: "ERROR; return code from pthread_create() is 11 Error detail: Resource temporarily unavailable"
@@ -132,7 +132,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         url_timeout:
             diagMessage: >
@@ -143,7 +143,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         p_fgcm_380:
             diagMessage: "Exception KeyError: (380, 40)"
@@ -152,7 +152,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0
         keyerror_0:
             diagMessage: |
@@ -163,7 +163,7 @@ pandaErrorCode:
             ticket: ["DM-37786", "DM-37570"]
             resolved: 1
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0
         outside_image_bounds:
             diagMessage: >
@@ -174,7 +174,7 @@ pandaErrorCode:
             ticket: ["DM-35722", "DM-36066"]
             resolved: 1
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_NaN_to_int_detection:
             diagMessage: >
@@ -185,7 +185,7 @@ pandaErrorCode:
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_all_pixels_masked:
             diagMessage: "All pixels masked. Cannot estimate background"
@@ -194,7 +194,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 1
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_psf_matching_kernel_subtractImages:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
@@ -203,7 +203,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         cannot_compute_coaddpsf:
             diagMessage: >
@@ -217,7 +217,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_kernel_candidacy:
             diagMessage: >
@@ -228,7 +228,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_do_compute_kernel_image:
             diagMessage: >
@@ -239,7 +239,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         kernel_does_not_exist:
             diagMessage: "Original kernel does not exist {0}; Visiting candidate {1}{{}}"
@@ -248,7 +248,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         kernel_sum:
             diagMessage: "Unable to determine kernel sum; 0 candidates"
@@ -257,7 +257,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_NaN_to_int_subtractImages:
             diagMessage: "Exception ValueError: cannot convert float NaN to integer"
@@ -266,7 +266,7 @@ pandaErrorCode:
             ticket: ["DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_array_sample_empty:
             diagMessage: "array of sample points is empty"
@@ -275,7 +275,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_fp_xp:
             diagMessage: "fp and xp are not of the same length."
@@ -284,7 +284,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         u_psf:
             diagMessage: >
@@ -295,7 +295,7 @@ pandaErrorCode:
             ticket: ["DM-36305", "DM-36356"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         p_remote_io:
             diagMessage: >
@@ -306,7 +306,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 1 # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
             rescue: 0
-            panda: 1 # later: mark as "usdf"
+            flavor: 1 # later: mark as "usdf"
             intensity: 0
     pilot, 1305:
         aperture_correction:
@@ -318,7 +318,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         psfex:
             diagMessage: >
@@ -329,7 +329,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         FWHM_value_of_nan:
             diagMessage: "Failed to execute payload:PSF at (.*) has an invalid FWHM value of nan"
@@ -338,7 +338,7 @@ pandaErrorCode:
             ticket: ["DM-37089"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         NaN_to_int_calibrate:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
@@ -347,7 +347,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         no_use_for_photocal:
             diagMessage: "Failed to execute payload:No matches to use for photocal"
@@ -356,7 +356,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         NaN_to_int_detection:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
@@ -365,7 +365,7 @@ pandaErrorCode:
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         all_pixels_masked:
             diagMessage: "Failed to execute payload:All pixels masked. Cannot estimate background"
@@ -374,7 +374,7 @@ pandaErrorCode:
             ticket: ["DM-37837", "DM-37570"]
             resolved: 1
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         vague_finalizeCharacterization:
             diagMessage: "Failed to execute payload"
@@ -383,7 +383,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
         do_compute_kernel_image:
             diagMessage: >
@@ -394,7 +394,7 @@ pandaErrorCode:
             ticket: ["DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         kernel_candidacy:
             diagMessage: "Failed to execute payload:Cannot find any objects suitable for KernelCandidacy"
@@ -403,7 +403,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         psf_matching_kernel_subtractImages:
             diagMessage: "Failed to execute payload:Unable to calculate psf matching kernel"
@@ -412,7 +412,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37089"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         array_sample_empty:
             diagMessage: "Failed to execute payload:array of sample points is empty"
@@ -421,7 +421,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         fp_xp:
             diagMessage: "Failed to execute payload:fp and xp are not of the same length."
@@ -430,7 +430,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         parquet_formatter:
             diagMessage: >
@@ -441,7 +441,7 @@ pandaErrorCode:
             ticket: ["DM-36306", "DM-36356"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0.001
         fgcm_380:
             diagMessage: "Failed to execute payload:(380, 40)"
@@ -450,7 +450,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 0
             rescue: 0
-            panda: 0
+            flavor: 0
             intensity: 0
         remote_io:
             diagMessage: "(psycopg2.errors.InternalError_) could not read block .* in file \".*\": Remote I/O error"
@@ -459,7 +459,7 @@ pandaErrorCode:
             ticket: ["DM-37570"]
             resolved: 1 # double check this
             rescue: 0
-            panda: 1 # later: mark as "usdf"
+            flavor: 1 # later: mark as "usdf"
             intensity: 0
     taskbuffer, 300:
         failed_while_starting_job:
@@ -469,7 +469,7 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36845", "DM-36763"]
             resolved: 0
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
     taskbuffer, 102:
         expired_in_pending:
@@ -479,7 +479,7 @@ pandaErrorCode:
             ticket: ["DM-37089"]
             resolved: 0
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
     pilot, 1344:
         resource_temporarily_unavailable:
@@ -489,7 +489,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
     trans, 134:
         sigabrt:
@@ -500,7 +500,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
     jobdispatcher, 102:
         no_reply:
@@ -510,7 +510,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
     jobdispatcher, 100:
         lost_heartbeat:
@@ -520,7 +520,7 @@ pandaErrorCode:
             ticket: ["DM-36356"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
     pilot, 1098:
         no_space_on_disk:
@@ -530,7 +530,7 @@ pandaErrorCode:
             ticket: ["DM-36066"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0
     trans, 137:
         sigkill:
@@ -540,5 +540,5 @@ pandaErrorCode:
             ticket: ["DM-37570", "DM-37483", "DM-36356", "DM-36741"]
             resolved: 1
             rescue: 1
-            panda: 1
+            flavor: 1
             intensity: 0

--- a/src/lsst/cm/tools/core/error_code_decisions.yaml
+++ b/src/lsst/cm/tools/core/error_code_decisions.yaml
@@ -6,7 +6,7 @@ pandaErrorCode:
             diagMessage: >
                 Unable to measure aperture correction for required algorithm 'modelfit_CModel': only .* sources, but
                 require at least 2
-            function: characterizeImage
+            pipetask: characterizeImage
             ticket: ["DM-37483", "DM-37089"]
             resolved: False
             rescue: False
@@ -16,7 +16,7 @@ pandaErrorCode:
             diagMessage: >
                 File "src/PsfexPsf.cc", line 233, in virtual std:shared_ptr > lsst:meas:extensions:psfex:PsfexPsf:
                 _doComputeImage(const Point2D&, const lsst:afw:image:Color&, const Point2D&) const
-            function: characterizeImage
+            pipetask: characterizeImage
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -24,7 +24,7 @@ pandaErrorCode:
             intensity: 0.001
         FWHM_value_of_nan:
             diagMessage: "Failed to execute payload:PSF at (.*) has an invalid FWHM value of nan"
-            function: calibrate
+            pipetask: calibrate
             ticket: ["DM-37089"]
             resolved: False
             rescue: False
@@ -32,7 +32,7 @@ pandaErrorCode:
             intensity: 0.001
         NaN_to_int_calibrate:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
-            function: calibrate
+            pipetask: calibrate
             ticket: ["DM-36356"]
             resolved: False
             rescue: False
@@ -40,7 +40,7 @@ pandaErrorCode:
             intensity: 0.001
         no_use_for_photocal:
             diagMessage: "Failed to execute payload:No matches to use for photocal"
-            function: calibrate
+            pipetask: calibrate
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: False
             rescue: False
@@ -48,7 +48,7 @@ pandaErrorCode:
             intensity: 0.001
         NaN_to_int_detection:
             diagMessage: "Failed to execute payload:cannot convert float NaN to integer"
-            function: detection
+            pipetask: detection
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -56,7 +56,7 @@ pandaErrorCode:
             intensity: 0.001
         all_pixels_masked:
             diagMessage: "Failed to execute payload:All pixels masked. Cannot estimate background"
-            function: detection
+            pipetask: detection
             ticket: ["DM-37837", "DM-37570"]
             resolved: True
             rescue: False
@@ -64,7 +64,7 @@ pandaErrorCode:
             intensity: 0.001
         too_many_indicies:
             diagMessage: "too many indices for array: array is 1-dimensional, but 2 were indexed"
-            function: detection
+            pipetask: detection
             ticket: ["DM-37837", "DM-37570"]
             resolved: True
             rescue: False
@@ -72,7 +72,7 @@ pandaErrorCode:
             intensity: 0.001
         vague_finalizeCharacterization:
             diagMessage: "Failed to execute payload"
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -82,7 +82,7 @@ pandaErrorCode:
             diagMessage: >
                 Failed to execute payload:File \"src/CoaddPsf.cc\", line 254, in virtual std:shared_ptr > lsst:meas:algorithms:
                 CoaddPsf:doComputeKernelImage(const Point2D&, const lsst:afw:image:Color&) const
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -90,7 +90,7 @@ pandaErrorCode:
             intensity: 0.001
         kernel_candidacy:
             diagMessage: "Failed to execute payload:Cannot find any objects suitable for KernelCandidacy"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -98,7 +98,7 @@ pandaErrorCode:
             intensity: 0.001
         psf_matching_kernel_subtractImages:
             diagMessage: "Failed to execute payload:Unable to calculate psf matching kernel"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570", "DM-37089"]
             resolved: False
             rescue: False
@@ -106,7 +106,7 @@ pandaErrorCode:
             intensity: 0.001
         array_sample_empty:
             diagMessage: "Failed to execute payload:array of sample points is empty"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -114,7 +114,7 @@ pandaErrorCode:
             intensity: 0.001
         fp_xp:
             diagMessage: "Failed to execute payload:fp and xp are not of the same length."
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -124,7 +124,7 @@ pandaErrorCode:
             diagMessage: >
                 Failed to execute payload:Failure from formatter 'lsst.daf.butler.formatters.parquet.ParquetFormatter' for dataset
                 .*
-            function: catalogMatchTract
+            pipetask: catalogMatchTract
             ticket: ["DM-36306", "DM-36356"]
             resolved: False
             rescue: False
@@ -132,7 +132,7 @@ pandaErrorCode:
             intensity: 0.001
         fgcm_380:
             diagMessage: "Failed to execute payload:(380, 40)"
-            function: fgcmBuildStarsTable
+            pipetask: fgcmBuildStarsTable
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -140,7 +140,7 @@ pandaErrorCode:
             intensity: 0
         remote_io:
             diagMessage: "(psycopg2.errors.InternalError_) could not read block .* in file \".*\": Remote I/O error"
-            function: mergeExecutionButler
+            pipetask: mergeExecutionButler
             ticket: ["DM-37570"]
             resolved: True # double check this
             rescue: False
@@ -152,7 +152,7 @@ pandaErrorCode:
                 Execution of task 'characterizeImage' on quantum {.*} failed. Exception
                 RuntimeError: Unable to measure aperture correction for required algorithm 'modelfit_CModel': only 0 sources, but
                 require at least 2.
-            function: characterizeImage
+            pipetask: characterizeImage
             ticket: ["DM-37483", "DM-37089", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
@@ -160,7 +160,7 @@ pandaErrorCode:
             intensity: 0.001
         p_psf_matching_kernel:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
-            function: characterizeImage
+            pipetask: characterizeImage
             ticket: ["DM-37570", "DM-37483", "DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -170,7 +170,7 @@ pandaErrorCode:
             diagMessage: >
                 Failed to solve for PSF matching kernel in GAaP for (.*): Problematic scaling factors = .* Errors: Exception
                 ('Unable to determine kernel sum; 0 candidates')
-            function: characterizeImage
+            pipetask: characterizeImage
             ticket: ["DM-37483", "DM-33375", "DM-36763", "DM-36356"]
             resolved: False
             rescue: False
@@ -178,7 +178,7 @@ pandaErrorCode:
             intensity: 0.001
         p_psfex:
             diagMessage: "Only spatial variation (ndim == 2) is supported; saw 0"
-            function: characterizeImage
+            pipetask: characterizeImage
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -188,7 +188,7 @@ pandaErrorCode:
             diagMessage: >
                 Execution of task 'calibrate' on quantum {.*} failed. Exception
                 RuntimeError: No matches to use for photocal
-            function: calibrate
+            pipetask: calibrate
             ticket: ["DM-37483", "DM-37089", "DM-32291", "DM-36763"]
             resolved: False
             rescue: False
@@ -198,7 +198,7 @@ pandaErrorCode:
             diagMessage: >
                 Execution of task 'calibrate' on quantum {.*} failed. Exception
                 ValueError: cannot convert float NaN to integer
-            function: calibrate
+            pipetask: calibrate
             ticket: ["DM-36356"]
             resolved: False
             rescue: False
@@ -208,7 +208,7 @@ pandaErrorCode:
             diagMessage: >
                 Execution of task 'calibrate' on quantum {.*} failed. Exception
                 ValueError: PSF at (.*) has an invalid FWHM value of nan
-            function: calibrate
+            pipetask: calibrate
             ticket: ["DM-37089", "DM-36763"]
             resolved: False
             rescue: False
@@ -219,7 +219,7 @@ pandaErrorCode:
                 Task <TaskDef(lsst.pipe.tasks.finalizeCharacterization.FinalizeCharacterizationTask, label=
                 finalizeCharacterization) dataId={.*}> failed; processing will continue for remaining
                 tasks.
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -227,7 +227,7 @@ pandaErrorCode:
             intensity: 0
         cant_start_new_thread:
             diagMessage: "RuntimeError: can't start new thread"
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -235,7 +235,7 @@ pandaErrorCode:
             intensity: 0
         rchar:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic rchar from .* to .*"
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -243,7 +243,7 @@ pandaErrorCode:
             intensity: 0
         read_bytes:
             diagMessage: "Error: attempt to reduce the monitored value of monotonic read_bytes from .* to .*"
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -252,7 +252,7 @@ pandaErrorCode:
         terminate_after_sys_err:
             diagMessage: >
                 terminate called after throwing an instance of 'std::system_error' what(): Resource temporarily unavailable
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -260,7 +260,7 @@ pandaErrorCode:
             intensity: 0
         pthread_create:
             diagMessage: "ERROR; return code from pthread_create() is 11 Error detail: Resource temporarily unavailable"
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -270,7 +270,7 @@ pandaErrorCode:
             diagMessage: >
                 url=/cvmfs/atlas.cern.ch/repo/sw/local/etc/cric_pandaqueues.json, error: TimeoutException: Timeout reached,
                 timeout=20 seconds .. trying to use data from cache=/tmp/atlas_4WNdEEY5/agis_schedconf.cvmfs.json
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -278,7 +278,7 @@ pandaErrorCode:
             intensity: 0
         p_fgcm_380:
             diagMessage: "Exception KeyError: (380, 40)"
-            function: fgcmBuildStarsTable
+            pipetask: fgcmBuildStarsTable
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -288,7 +288,7 @@ pandaErrorCode:
             diagMessage: |
                 exposure = input_exposures[detector_id].get()
                 KeyError: 0
-            function: updateVisitSummary
+            pipetask: updateVisitSummary
             ticket: ["DM-37786", "DM-37570"]
             resolved: True
             rescue: False
@@ -298,7 +298,7 @@ pandaErrorCode:
             diagMessage: >
                 Execution of task 'measure' on quantum {.*} failed. Exception
                 IndexError: Index (.*) outside image bounds (.*) to (.*).
-            function: measure
+            pipetask: measure
             ticket: ["DM-35722", "DM-36066"]
             resolved: True
             rescue: False
@@ -308,7 +308,7 @@ pandaErrorCode:
             diagMessage: >
                 Execution of task 'detection' on quantum {.*} failed. Exception
                 ValueError: cannot convert float NaN to integer
-            function: detection
+            pipetask: detection
             ticket: ["DM-36763", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -316,7 +316,7 @@ pandaErrorCode:
             intensity: 0.001
         p_all_pixels_masked:
             diagMessage: "All pixels masked. Cannot estimate background"
-            function: detection
+            pipetask: detection
             ticket: ["DM-37570"]
             resolved: True
             rescue: False
@@ -324,7 +324,7 @@ pandaErrorCode:
             intensity: 0.001
         p_psf_matching_kernel_subtractImages:
             diagMessage: "ERROR: Unable to calculate psf matching kernel"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -337,7 +337,7 @@ pandaErrorCode:
                 Image<double> > lsst::meas::algorithms::CoaddPsf::doComputeKernelImage(const Point2D&, const lsst::afw::image::
                 Color&) const\nCannot compute CoaddPsf at point (.*); no input images at that point. {0} lsst::pex::exceptions::
                 InvalidParameterError: 'Cannot compute CoaddPsf at point (.*); no input images at that point.'
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570", "DM-37483", "DM-37089", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -347,7 +347,7 @@ pandaErrorCode:
             diagMessage: >
                 Execution of task 'subtractImages' on quantum {.*} failed. Exception
                 RuntimeError: Cannot find any objects suitable for KernelCandidacy
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -357,7 +357,7 @@ pandaErrorCode:
             diagMessage: >
                 File "src/CoaddPsf.cc", line 254, in virtual std:shared_ptr > lsst:meas:
                 algorithms:CoaddPsf:doComputeKernelImage(const Point2D&, const lsst:afw:image:Color&) const"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -365,7 +365,7 @@ pandaErrorCode:
             intensity: 0.001
         kernel_does_not_exist:
             diagMessage: "Original kernel does not exist {0}; Visiting candidate {1}{{}}"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570", "DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -373,7 +373,7 @@ pandaErrorCode:
             intensity: 0.001
         kernel_sum:
             diagMessage: "Unable to determine kernel sum; 0 candidates"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37483", "DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -381,7 +381,7 @@ pandaErrorCode:
             intensity: 0.001
         p_NaN_to_int_subtractImages:
             diagMessage: "Exception ValueError: cannot convert float NaN to integer"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-36265", "DM-36356", "DM-36066"]
             resolved: False
             rescue: False
@@ -389,7 +389,7 @@ pandaErrorCode:
             intensity: 0.001
         p_array_sample_empty:
             diagMessage: "array of sample points is empty"
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -397,7 +397,7 @@ pandaErrorCode:
             intensity: 0.001
         p_fp_xp:
             diagMessage: "fp and xp are not of the same length."
-            function: subtractImages
+            pipetask: subtractImages
             ticket: ["DM-37570"]
             resolved: False
             rescue: False
@@ -407,7 +407,7 @@ pandaErrorCode:
             diagMessage: >
                 Exception ValueError: Failure from formatter 'lsst.daf.butler.formatters.parquet.ParquetFormatter' for
                 dataset .*: Unrecognized column name 'u_psfFlux_flag'.
-            function: catalogMatchTract
+            pipetask: catalogMatchTract
             ticket: ["DM-36305", "DM-36356"]
             resolved: False
             rescue: False
@@ -417,7 +417,7 @@ pandaErrorCode:
             diagMessage: >
                 sqlalchemy.exc.InternalError: (psycopg2.errors.InternalError_) could not read block .* in file ".*":
                 Remote I/O error
-            function: mergeExecutionButler
+            pipetask: mergeExecutionButler
             ticket: ["DM-37570"]
             resolved: True # DM-38007 needs to include a way to mark that if we see this the merge job should be re-run
             rescue: False
@@ -426,7 +426,7 @@ pandaErrorCode:
     taskbuffer, 300:
         failed_while_starting_job:
             diagMessage: "The worker was failed while the job was starting : .* gridjob roma shared .* FAILED .*."
-            function:
+            pipetask:
             ticket: ["DM-37570", "DM-37483", "DM-36845", "DM-36763"]
             resolved: False
             rescue: True
@@ -435,7 +435,7 @@ pandaErrorCode:
     taskbuffer, 102:
         expired_in_pending:
             diagMessage: "expired in pending. status unchanged"
-            function:
+            pipetask:
             ticket: ["DM-37089"]
             resolved: False
             rescue: True
@@ -444,7 +444,7 @@ pandaErrorCode:
     pilot, 1344:
         resource_temporarily_unavailable:
             diagMessage: "Exception caught: [Errno 11] Resource temporarily unavailable"
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -454,7 +454,7 @@ pandaErrorCode:
         sigabrt:
             diagMessage: >
                 New trf: Transform received signal SIGABRT; Old trf: Athena core dump or timeout, or conddb DB connect exception
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -463,7 +463,7 @@ pandaErrorCode:
     jobdispatcher, 102:
         no_reply:
             diagMessage: "Sent job didn't receive reply from pilot within 30 min"
-            function: finalizeCharacterization
+            pipetask: finalizeCharacterization
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -472,7 +472,7 @@ pandaErrorCode:
     jobdispatcher, 100:
         lost_heartbeat:
             diagMessage: "lost heartbeat"
-            function:
+            pipetask:
             ticket: ["DM-36356"]
             resolved: True
             rescue: True
@@ -481,7 +481,7 @@ pandaErrorCode:
     pilot, 1098:
         no_space_on_disk:
             diagMessage: "too little space left on local disk to run job: .* B (need > .* B)"
-            function: forcedPhotCcd
+            pipetask: forcedPhotCcd
             ticket: ["DM-36066"]
             resolved: True
             rescue: True
@@ -490,7 +490,7 @@ pandaErrorCode:
     trans, 137:
         sigkill:
             diagMessage: "Transform received signal SIGKILL"
-            function:
+            pipetask:
             ticket: ["DM-37570", "DM-37483", "DM-36356", "DM-36741"]
             resolved: True
             rescue: True

--- a/src/lsst/cm/tools/db/error_table.py
+++ b/src/lsst/cm/tools/db/error_table.py
@@ -13,7 +13,7 @@ class ErrorFlavor(enum.Enum):
 
     pipelines = 0
     panda = 1
-    usdf_is_on_fire = 2
+    usdf = 2
 
 
 class ErrorAction(enum.Enum):


### PR DESCRIPTION
- Change `panda` to `flavor` (an enum which describes different kinds of errors; ie, PanDa vs. USDF vs. pipelines errors)
- Change 1/0 to True/False for boolean values
- List pilot errors first
- Delete `known` field
- Related discussions on the ticket will become their own Jira tickets. This branch should be merged so it can be used.