### PR TITLE
DM-38436: cm load-error-types says pipelines is not a valid ErrorFlavor in cm_tools

### DIFF
--- a/src/lsst/cm/tools/db/sqlalch_interface.py
+++ b/src/lsst/cm/tools/db/sqlalch_interface.py
@@ -506,8 +506,8 @@ class SQLAlchemyInterface(DbInterface):
                     pipetask=error_type["pipetask"],
                     is_resolved=error_type["resolved"],
                     is_rescueable=error_type["rescue"],
-                    error_flavor=ErrorFlavor(error_type["flavor"]),
-                    action=ErrorAction["email_orion"],
+                    error_flavor=ErrorFlavor[error_type["flavor"]],
+                    action=ErrorAction["failed_review"],
                     max_intensity=error_type["intensity"],
                 )
                 try:


### PR DESCRIPTION
Fixed enum syntax in load_error_types and updated naming scheme of de…fault ErrorAction from email_orion to failed_review. This bug fix is tiny but I am happy it's on its own branch so I can merge to main.