### PR TITLE
added failed back into the panda_status_map

### DIFF
--- a/src/lsst/cm/tools/core/panda_utils.py
+++ b/src/lsst/cm/tools/core/panda_utils.py
@@ -399,6 +399,7 @@ class PandaChecker(SlurmChecker):  # pragma: no cover
         done=StatusEnum.completed,
         running=StatusEnum.running,
         accept=StatusEnum.completed,
+        failed=StatusEnum.reviewable,
         failed_rescue=StatusEnum.rescuable,
         failed_review=StatusEnum.reviewable,
         # TODO: add handling for cleanup state and an associated Enum


### PR DESCRIPTION
Pretty quick fix. This maps the panda status of failed (aka not a single psuedofile got its output) as failed_review, which is the same point that we put entirely unknown crashes.

It's possible this should get different treatment in the future, but at this point it seems like if something like this helps we want people to be putting human eyes on it.