### PR TITLE
Use `subprocess.run` instead of `os.system` for better portability

### DIFF
--- a/src/lsst/cm/tools/db/job_handler.py
+++ b/src/lsst/cm/tools/db/job_handler.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from typing import Any
 
 import yaml
@@ -162,7 +163,7 @@ class JobHandler(JobHandlerBase):
         elif job.script_method == ScriptMethod.no_script:  # pragma: no cover
             status = StatusEnum.running
         elif job.script_method == ScriptMethod.bash:
-            os.system(f"source {job.script_url}")
+            subprocess.run(["/bin/bash", job.script_url])
             status = StatusEnum.running
         elif job.script_method == ScriptMethod.slurm:  # pragma: no coveres
             job_id = submit_job(job.script_url, job.log_url)

--- a/src/lsst/cm/tools/db/script_handler.py
+++ b/src/lsst/cm/tools/db/script_handler.py
@@ -1,4 +1,4 @@
-import os
+import subprocess
 from typing import Any
 
 from lsst.cm.tools.core.db_interface import DbInterface, ScriptBase
@@ -122,7 +122,7 @@ class ScriptHandler(ScriptHandlerBase):
             return StatusEnum.running
         self.write_script_hook(dbi, parent, script, **kwargs)
         if script.script_method == ScriptMethod.bash:
-            os.system(f"source {script.script_url}")
+            subprocess.run(["/bin/bash", script.script_url])
         elif script.script_method == ScriptMethod.slurm:  # pragma: no cover
             job_id = submit_job(script.script_url, script.log_url)
             Script.update_values(dbi, script.id, stamp_url=job_id)


### PR DESCRIPTION
Python `os.system("source ...")` has been observed to fail on some Linux systems which run `sh` in strict POSIX compatibility mode.  `os.system(". ...")` appears to be more portable, but the python docs themselves say that `subprocess.run(...)` is to be preferred in new code. 