### PR TITLE
one line fix to remove w from the fullname in internal use

### DIFF
--- a/src/lsst/cm/tools/db/sqlalch_interface.py
+++ b/src/lsst/cm/tools/db/sqlalch_interface.py
@@ -76,7 +76,9 @@ class SQLAlchemyInterface(DbInterface):
         if n_tokens >= 4:
             names["group_name"] = tokens[3]
         if n_tokens >= 5:
-            names["workflow_idx"] = tokens[4]
+            # this strip helps with internal database
+            # calls
+            names["workflow_idx"] = tokens[4].strip("w")
         return names
 
     def _get_db_id_from_fullname(self, fullname: str) -> DbId:


### PR DESCRIPTION
I think this should be sufficient to strip the w from the fullname internally so that only the idx passes around.

There's technically the --workflow-idx option which still requires an idx, but I think that should be fine since it is pretty clear that it is the index that it requires.