### PR TITLE
DM-39535: Do clever stuff with cm report-errors

### DIFF
--- a/src/lsst/cm/tools/cli/commands.py
+++ b/src/lsst/cm/tools/cli/commands.py
@@ -558,6 +558,15 @@ def rematch_errors(dbi: DbInterface) -> None:
 @cli.command()
 @options.dbi()
 @options.config_yaml()
+@options.error_yaml()
+def match_file_errors(dbi: DbInterface, config_yaml: str, error_yaml: str) -> None:
+    """Match errors against existing error types in a file"""
+    dbi.match_file_errors(config_yaml, error_yaml)
+
+
+@cli.command()
+@options.dbi()
+@options.config_yaml()
 @options.config_name()
 def extend(dbi: DbInterface, config_yaml: str, config_name: str) -> None:
     """Parse a configuration file and add the fragments to another config"""

--- a/src/lsst/cm/tools/cli/commands.py
+++ b/src/lsst/cm/tools/cli/commands.py
@@ -601,6 +601,7 @@ def get_panda_errors(dbi: DbInterface, panda_url: int, panda_username: str):
 @options.fullname()
 @options.summary()
 @options.review()
+@options.yaml_output()
 def report_errors(
     dbi: DbInterface,
     **kwargs: Any,

--- a/src/lsst/cm/tools/cli/options.py
+++ b/src/lsst/cm/tools/cli/options.py
@@ -20,6 +20,7 @@ __all__ = [
     "diag_message",
     "dbi",
     "error_name",
+    "error_yaml",
     "fmt",
     "fullname",
     "group",
@@ -311,6 +312,12 @@ diag_message = PartialOption(
 error_name = PartialOption(
     "--error-name",
     help="Unique name for this ErrorType.",
+)
+
+error_yaml = PartialOption(
+    "--error-yaml",
+    type=click.Path(),
+    help="Yaml file with errors to match",
 )
 
 update_item = PartialOption(

--- a/src/lsst/cm/tools/cli/options.py
+++ b/src/lsst/cm/tools/cli/options.py
@@ -48,6 +48,7 @@ __all__ = [
     "update_item",
     "verbose",
     "workflow",
+    "yaml_output",
 ]
 
 
@@ -324,6 +325,13 @@ update_item = PartialOption(
     "--update-item",
     type=(str, str),
     help="Item to update in Error.",
+)
+
+yaml_output = PartialOption(
+    "--yaml-output",
+    default=False,
+    help="print output in yaml format",
+    is_flag=True,
 )
 
 

--- a/src/lsst/cm/tools/core/db_interface.py
+++ b/src/lsst/cm/tools/core/db_interface.py
@@ -978,8 +978,21 @@ class DbInterface:
         """
         raise NotImplementedError()
 
-    def rematch_errors(self) -> Any:
+    def rematch_errors(self, **kwargs: Any) -> Any:
         """Rematch the error instances"""
+        raise NotImplementedError()
+
+    def match_file_errors(self, config_yaml: str, error_file: str) -> None:
+        """Match the error instances to an error file
+
+        Parameters
+        ----------
+        config_yaml: str
+            File with the known error types
+
+        error_file: str
+            File the errors
+        """
         raise NotImplementedError()
 
     def extend_config(self, config_name: str, config_yaml: str) -> ConfigBase:

--- a/src/lsst/cm/tools/db/sqlalch_interface.py
+++ b/src/lsst/cm/tools/db/sqlalch_interface.py
@@ -635,10 +635,7 @@ class SQLAlchemyInterface(DbInterface):
         return
 
     def match_error_type_against_dict(self, error_dict: Any, panda_code: str, diag_message: str) -> Any:
-        try:
-            possible_matches = error_dict[panda_code]
-        except KeyError:
-            possible_matches = {}
+        possible_matches = error_dict.get(panda_code, {})
         for key, val in possible_matches.items():
             if re.match(val["diagMessage"].strip(), diag_message):
                 return key

--- a/src/lsst/cm/tools/db/sqlalch_interface.py
+++ b/src/lsst/cm/tools/db/sqlalch_interface.py
@@ -700,7 +700,7 @@ class SQLAlchemyInterface(DbInterface):
     def report_errors(self, stream: TextIO, level: LevelEnum, db_id: DbId, **kwargs: Any) -> None:
         review_only = kwargs.get("review", False)
         summary_only = kwargs.get("summary", False)
-        yaml_output = kwargs.get("yaml_output", True)
+        yaml_output = kwargs.get("yaml_output", False)
         entry = self.get_entry(level, db_id)
         error_dict = {}
         for job_ in entry.jobs_:


### PR DESCRIPTION
This allow you to work with the errors more easily.

```
cm report-errors --fullname PDR2/v24.1.0.rc2_DM-39132_deep/step1 --yaml-output > error_file.yaml
cm match-file-errors --config-yaml examples/error_code_decisions_new.yaml --error-yaml error_file.yaml
<add error types to examples/error_code_decisions_new.yaml to match the reported errors until there are no more unmatched errors>

```

Then you can do

```
(cmtools) [echarles@sdfrome002 cm_prod]$ cm match-file-errors --config-yaml examples/error_code_decisions_new.yaml --error-yaml error_file.yaml 
Matched Errors
aperture_correction, 308
no_objects_for_psf, 12
psfex_image, 1394
astrometry_failure, 48
unable_to_match, 24
failed_to_fit_scatter, 2
Unmatched Errors
```

Then you can do:

```
cm load-error-types --config-yaml examples/error_code_decisions_new.yaml
cm rematch-errors

```
And now all your errors are matched to know error types.