### PR TITLE
DM-40211: Add 'closed' to list of failed states in jtid_status_map in cm_tools

### DIFF
--- a/src/lsst/cm/tools/core/panda_utils.py
+++ b/src/lsst/cm/tools/core/panda_utils.py
@@ -277,6 +277,7 @@ jtid_status_map = dict(
     toretry="running",
     failed="failed",
     toincexec="running",
+    closed="failed",
 )
 
 


### PR DESCRIPTION
Previously, `cm report-errors` was not reporting closed job failures because of this. Quick bug fix.